### PR TITLE
feat: clean not used vars, constants and functions

### DIFF
--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -27,6 +27,7 @@ import {
   START_DATE,
   END_DATE,
   ALLOW_FAILURE_MAP,
+  METADATA,
 } from '../utils/constants';
 import {
   createNewMembersAddedEvent,
@@ -72,8 +73,6 @@ const proposalEntityId = generateProposalEntityId(
   pluginAddress,
   pluginProposalId
 );
-
-export const METADATA = 'Some String Data ...';
 
 describe('Plugin', () => {
   beforeEach(function () {

--- a/packages/subgraph/tests/plugin/plugin.test.ts
+++ b/packages/subgraph/tests/plugin/plugin.test.ts
@@ -20,6 +20,13 @@ import {
   ADDRESS_THREE_STRING,
   CONTRACT_ADDRESS_STRING,
   DAO_ADDRESS_STRING,
+  PLUGIN_PROPOSAL_ID,
+  SNAPSHOT_BLOCK,
+  ONE,
+  TWO,
+  START_DATE,
+  END_DATE,
+  ALLOW_FAILURE_MAP,
 } from '../utils/constants';
 import {
   createNewMembersAddedEvent,
@@ -32,13 +39,6 @@ import {
   createGetProposalCall,
   createNewMultisigSettingsUpdatedEvent,
   createMultisigPluginState,
-  PLUGIN_PROPOSAL_ID,
-  SNAPSHOT_BLOCK,
-  ONE,
-  TWO,
-  START_DATE,
-  END_DATE,
-  ALLOW_FAILURE_MAP,
 } from '../utils/events';
 import {
   generatePluginEntityId,

--- a/packages/subgraph/tests/utils/constants.ts
+++ b/packages/subgraph/tests/utils/constants.ts
@@ -41,3 +41,5 @@ export const END_DATE = '1644852000';
 export const CREATED_AT = ONE;
 export const SNAPSHOT_BLOCK = '100';
 export const ALLOW_FAILURE_MAP = '1';
+
+export const METADATA = 'Some String Data ...';

--- a/packages/subgraph/tests/utils/constants.ts
+++ b/packages/subgraph/tests/utils/constants.ts
@@ -1,29 +1,43 @@
 import {Address} from '@graphprotocol/graph-ts';
 
+export const ZERO = '0';
+export const ONE = '1';
+export const TWO = '2';
+export const THREE = '3';
+
 // String and Address type constants for test scenarios:
 // ADDRESS_ZERO to ADDRESS_SIX: Dummy Ethereum addresses for various test cases.
 // DAO_ADDRESS: A placeholder address for a DAO instance.
 // CONTRACT_ADDRESS: A placeholder address for a contract instance.
 // PLUGIN_SETUP_ID: A mock identifier for a plugin setup in test simulations.
 export const ADDRESS_ZERO_STRING = '0x0000000000000000000000000000000000000000';
-export const ADDRESS_ZERO = Address.fromString(ADDRESS_ZERO_STRING);
 export const ADDRESS_ONE_STRING = '0x0000000000000000000000000000000000000001';
-export const ADDRESS_ONE = Address.fromString(ADDRESS_ONE_STRING);
 export const ADDRESS_TWO_STRING = '0x0000000000000000000000000000000000000002';
-export const ADDRESS_TWO = Address.fromString(ADDRESS_TWO_STRING);
 export const ADDRESS_THREE_STRING =
   '0x0000000000000000000000000000000000000003';
-export const ADDRESS_THREE = Address.fromString(ADDRESS_THREE_STRING);
 export const ADDRESS_FOUR_STRING = '0x0000000000000000000000000000000000000004';
-export const ADDRESS_FOUR = Address.fromString(ADDRESS_FOUR_STRING);
 export const ADDRESS_FIVE_STRING = '0x0000000000000000000000000000000000000005';
-export const ADDRESS_FIVE = Address.fromString(ADDRESS_FIVE_STRING);
 export const ADDRESS_SIX_STRING = '0x0000000000000000000000000000000000000006';
-export const ADDRESS_SIX = Address.fromString(ADDRESS_SIX_STRING);
 export const DAO_ADDRESS_STRING = '0x00000000000000000000000000000000000000da';
-export const DAO_ADDRESS = Address.fromString(DAO_ADDRESS_STRING);
 export const CONTRACT_ADDRESS_STRING =
   '0x00000000000000000000000000000000000000Ad';
+
+export const ADDRESS_ZERO = Address.fromString(ADDRESS_ZERO_STRING);
+export const ADDRESS_ONE = Address.fromString(ADDRESS_ONE_STRING);
+export const ADDRESS_TWO = Address.fromString(ADDRESS_TWO_STRING);
+export const ADDRESS_THREE = Address.fromString(ADDRESS_THREE_STRING);
+export const ADDRESS_FOUR = Address.fromString(ADDRESS_FOUR_STRING);
+export const ADDRESS_FIVE = Address.fromString(ADDRESS_FIVE_STRING);
+export const ADDRESS_SIX = Address.fromString(ADDRESS_SIX_STRING);
+export const DAO_ADDRESS = Address.fromString(DAO_ADDRESS_STRING);
 export const CONTRACT_ADDRESS = Address.fromString(CONTRACT_ADDRESS_STRING);
+
 export const PLUGIN_SETUP_ID =
   '0xfb3fd2c4cd4e19944dd3f8437e67476240cd9e3efb2294ebd10c59c8f1d6817c';
+
+export const PLUGIN_PROPOSAL_ID = ZERO;
+export const START_DATE = '1644851000';
+export const END_DATE = '1644852000';
+export const CREATED_AT = ONE;
+export const SNAPSHOT_BLOCK = '100';
+export const ALLOW_FAILURE_MAP = '1';

--- a/packages/subgraph/tests/utils/events/plugin.ts
+++ b/packages/subgraph/tests/utils/events/plugin.ts
@@ -12,6 +12,15 @@ import {
   DAO_ADDRESS,
   CONTRACT_ADDRESS,
   CONTRACT_ADDRESS_STRING,
+  PLUGIN_PROPOSAL_ID,
+  ALLOW_FAILURE_MAP,
+  SNAPSHOT_BLOCK,
+  CREATED_AT,
+  START_DATE,
+  END_DATE,
+  TWO,
+  THREE,
+  ZERO,
 } from '../constants';
 import {
   generatePluginEntityId,
@@ -19,21 +28,6 @@ import {
 } from '@aragon/osx-commons-subgraph';
 import {Address, BigInt, Bytes, ethereum} from '@graphprotocol/graph-ts';
 import {createMockedFunction, newMockEvent} from 'matchstick-as';
-
-// test data
-
-export const ZERO = '0';
-export const ONE = '1';
-export const TWO = '2';
-export const THREE = '3';
-
-export const PLUGIN_PROPOSAL_ID = ZERO;
-export const MIN_PROPOSER_VOTING_POWER = ZERO;
-export const START_DATE = '1644851000';
-export const END_DATE = '1644852000';
-export const CREATED_AT = ONE;
-export const SNAPSHOT_BLOCK = '100';
-export const ALLOW_FAILURE_MAP = '1';
 
 // events
 


### PR DESCRIPTION
This Pr removes the not-used vars functions and constants in the voting vote subgraph. 
Also moves the defined constants to the constants file