### PR TITLE
fix: remove upgrade plugin permission granted to Dao

### DIFF
--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,5 +16,5 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Bumped OpenZepplin to `4.9.6`.
 - Used `ProxyLib` from `osx-commons-contracts` for the UUPS proxy deployment in `MultisigSetup`.
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `MultisigSetup` until it is available in `PermissionLib`.
-- Removed the Upgrade Plugin permission granted to the Dao during the `prepareInstallation` phase.
-- Updated `prepareUpdate` function to revoke the Upgrade Plugin permission on previous plugin builds when it was granted.
+- Adjusted `prepareInstallation` in `MultisigSetup` to stop granting the `UPDATE_MULTISIG_SETTINGS_PERMISSION` to the Dao.
+- Updated `prepareUpdate` function in `MultisigSetup`, to revoke the `UPDATE_MULTISIG_SETTINGS_PERMISSION` from earlier plugin builds when it was granted.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,3 +16,5 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Bumped OpenZepplin to `4.9.6`.
 - Used `ProxyLib` from `osx-commons-contracts` for the UUPS proxy deployment in `MultisigSetup`.
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `MultisigSetup` until it is available in `PermissionLib`.
+- Removed the Upgrade Plugin permission granted to the Dao during the `prepareInstallation` phase.
+- Updated `prepareUpdate` function to revoke the Upgrade Plugin permission on previous plugin builds when it was granted.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,5 +16,5 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Bumped OpenZepplin to `4.9.6`.
 - Used `ProxyLib` from `osx-commons-contracts` for the UUPS proxy deployment in `MultisigSetup`.
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `MultisigSetup` until it is available in `PermissionLib`.
-- Adjusted `prepareInstallation` in `MultisigSetup` to stop granting the `UPDATE_MULTISIG_SETTINGS_PERMISSION` to the Dao.
-- Updated `prepareUpdate` function in `MultisigSetup`, to revoke the `UPDATE_MULTISIG_SETTINGS_PERMISSION` from earlier plugin builds when it was granted.
+- Adjusted `prepareInstallation` in `MultisigSetup` to stop granting the `UPGRADE_PLUGIN_PERMISSION_ID` to the Dao.
+- Updated `prepareUpdate` function in `MultisigSetup`, to revoke the `UPGRADE_PLUGIN_PERMISSION_ID` from earlier plugin builds when it was granted.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -16,5 +16,5 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Bumped OpenZepplin to `4.9.6`.
 - Used `ProxyLib` from `osx-commons-contracts` for the UUPS proxy deployment in `MultisigSetup`.
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `MultisigSetup` until it is available in `PermissionLib`.
-- Adjusted `prepareInstallation` in `MultisigSetup` to stop granting the `UPGRADE_PLUGIN_PERMISSION_ID` to the Dao.
-- Updated `prepareUpdate` function in `MultisigSetup` to revoke the `UPGRADE_PLUGIN_PERMISSION_ID` from earlier plugin builds when it was granted.
+- Changed the `prepareInstallation` function in `MultisigSetup` to not unnecessarily grant the `UPGRADE_PLUGIN_PERMISSION_ID` permission to the installing DAO.
+- Changed the `prepareUpdate` function in `MultisigSetup` to revoke the previously unnecessarily granted `UPGRADE_PLUGIN_PERMISSION_ID` permission from the installing DAO.

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -17,4 +17,4 @@ and this project adheres to the [Aragon OSx Plugin Versioning Convention](https:
 - Used `ProxyLib` from `osx-commons-contracts` for the UUPS proxy deployment in `MultisigSetup`.
 - Hard-coded the `bytes32 internal constant EXECUTE_PERMISSION_ID` constant in `MultisigSetup` until it is available in `PermissionLib`.
 - Adjusted `prepareInstallation` in `MultisigSetup` to stop granting the `UPGRADE_PLUGIN_PERMISSION_ID` to the Dao.
-- Updated `prepareUpdate` function in `MultisigSetup`, to revoke the `UPGRADE_PLUGIN_PERMISSION_ID` from earlier plugin builds when it was granted.
+- Updated `prepareUpdate` function in `MultisigSetup` to revoke the `UPGRADE_PLUGIN_PERMISSION_ID` from earlier plugin builds when it was granted.

--- a/packages/contracts/src/MultisigSetup.sol
+++ b/packages/contracts/src/MultisigSetup.sol
@@ -74,7 +74,7 @@ contract MultisigSetup is PluginUpgradeableSetup {
     /// @dev Revoke the upgrade plugin permission from the DAO for all builds previous to the current one (3).
     function prepareUpdate(
         address _dao,
-        uint16 _currentBuild,
+        uint16 _fromBuild,
         SetupPayload calldata _payload
     )
         external
@@ -85,7 +85,7 @@ contract MultisigSetup is PluginUpgradeableSetup {
         (initData);
 
         // all builds previous current one (3) have this permission granted and need to be revoked
-        if (_currentBuild < 3) {
+        if (_fromBuild < 3) {
             PermissionLib.MultiTargetPermission[]
                 memory permissions = new PermissionLib.MultiTargetPermission[](1);
 

--- a/packages/contracts/src/MultisigSetup.sol
+++ b/packages/contracts/src/MultisigSetup.sol
@@ -71,7 +71,7 @@ contract MultisigSetup is PluginUpgradeableSetup {
     }
 
     /// @inheritdoc IPluginSetup
-    /// @dev Revoke the upgrade plugin permission from the DAO for all builds previous to the current one (3).
+    /// @dev Revoke the upgrade plugin permission to the DAO for all builds prior the current one (3).
     function prepareUpdate(
         address _dao,
         uint16 _fromBuild,
@@ -83,8 +83,6 @@ contract MultisigSetup is PluginUpgradeableSetup {
         returns (bytes memory initData, PreparedSetupData memory preparedSetupData)
     {
         (initData);
-
-        // all builds previous current one (3) have this permission granted and need to be revoked
         if (_fromBuild < 3) {
             PermissionLib.MultiTargetPermission[]
                 memory permissions = new PermissionLib.MultiTargetPermission[](1);

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - TODO TODO.",
+  "change": "v1.3\n - Stop granting Upgrade Plugin permission to the Dao since it is not needed.\n ",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Removed the unnecessary permission for the Dao to upgrade the plugin. These permissions will be automatically removed during updates from previous versions.\n ",
+  "change": "v1.3\n - Removed the unnecessary permission for the Dao to upgrade the plugin. This permission granted on previous versions, will be automatically removed during update.\n",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Removed the unnecessary permission for the Dao to upgrade the plugin. This permission granted on previous versions, will be automatically removed during update.\n",
+  "change": "v1.3\n - Removed an unneccessary permission that allowed the Dao to upgrade the plugin, because this is supposed to happens as part of the update itself. The unnecessary permission, which was granted on installation of previous versions, will be automatically removed with the update to this version.\n",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/src/build-metadata.json
+++ b/packages/contracts/src/build-metadata.json
@@ -1,6 +1,6 @@
 {
   "ui": {},
-  "change": "v1.3\n - Stop granting Upgrade Plugin permission to the Dao since it is not needed.\n ",
+  "change": "v1.3\n - Removed the unnecessary permission for the Dao to upgrade the plugin. These permissions will be automatically removed during updates from previous versions.\n ",
   "pluginSetup": {
     "prepareInstallation": {
       "description": "The information required for the installation.",

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -333,7 +333,7 @@ describe('MultisigSetup', function () {
   });
 
   describe('prepareUpdate', async () => {
-    it('update from build 1 should return correct permissions', async () => {
+    it('returns the permissions expected for the update from build 1', async () => {
       const {pluginSetup, dao} = await loadFixture(fixture);
       const plugin = ethers.Wallet.createRandom().address;
 
@@ -366,7 +366,7 @@ describe('MultisigSetup', function () {
       ]);
     });
 
-    it('update from build 2 should return correct permissions', async () => {
+    it('returns the permissions expected for the update from build 2', async () => {
       const {pluginSetup, dao} = await loadFixture(fixture);
       const plugin = ethers.Wallet.createRandom().address;
 

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -274,7 +274,7 @@ describe('MultisigSetup', function () {
       // Check the return data.
       expect(plugin).to.be.equal(anticipatedPluginAddress);
       expect(helpers.length).to.be.equal(0);
-      expect(permissions.length).to.be.equal(3);
+      expect(permissions.length).to.be.equal(2);
       expect(permissions).to.deep.equal([
         [
           Operation.Grant,
@@ -282,13 +282,6 @@ describe('MultisigSetup', function () {
           dao.address,
           AddressZero,
           UPDATE_MULTISIG_SETTINGS_PERMISSION_ID,
-        ],
-        [
-          Operation.Grant,
-          plugin,
-          dao.address,
-          AddressZero,
-          PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
         ],
         [
           Operation.Grant,
@@ -340,26 +333,70 @@ describe('MultisigSetup', function () {
   });
 
   describe('prepareUpdate', async () => {
-    it('should return nothing', async () => {
+    it('update from build 1 should return correct permissions', async () => {
       const {pluginSetup, dao} = await loadFixture(fixture);
+      const plugin = ethers.Wallet.createRandom().address;
 
       // Make a static call to check that the plugin update data being returned is correct.
-      const prepareUpdateData = await pluginSetup.callStatic.prepareUpdate(
-        dao.address,
-        VERSION.build,
-        {
-          currentHelpers: [
-            ethers.Wallet.createRandom().address,
-            ethers.Wallet.createRandom().address,
-          ],
-          data: [],
-          plugin: ethers.Wallet.createRandom().address,
-        }
-      );
+      const {
+        initData: initData,
+        preparedSetupData: {helpers, permissions},
+      } = await pluginSetup.callStatic.prepareUpdate(dao.address, 1, {
+        currentHelpers: [
+          ethers.Wallet.createRandom().address,
+          ethers.Wallet.createRandom().address,
+        ],
+        data: [],
+        plugin,
+      });
+
       // Check the return data.
-      expect(prepareUpdateData.initData).to.be.eq('0x');
-      expect(prepareUpdateData.preparedSetupData.permissions).to.be.eql([]);
-      expect(prepareUpdateData.preparedSetupData.helpers).to.be.eql([]);
+      expect(initData).to.be.eq('0x');
+      expect(permissions.length).to.be.eql(1);
+      expect(helpers).to.be.eql([]);
+      // check correct permission is revoked
+      expect(permissions).to.deep.equal([
+        [
+          Operation.Revoke,
+          plugin,
+          dao.address,
+          AddressZero,
+          PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
+        ],
+      ]);
+    });
+
+    it('update from build 2 should return correct permissions', async () => {
+      const {pluginSetup, dao} = await loadFixture(fixture);
+      const plugin = ethers.Wallet.createRandom().address;
+
+      // Make a static call to check that the plugin update data being returned is correct.
+      const {
+        initData: initData,
+        preparedSetupData: {helpers, permissions},
+      } = await pluginSetup.callStatic.prepareUpdate(dao.address, 2, {
+        currentHelpers: [
+          ethers.Wallet.createRandom().address,
+          ethers.Wallet.createRandom().address,
+        ],
+        data: [],
+        plugin,
+      });
+
+      // Check the return data.
+      expect(initData).to.be.eq('0x');
+      expect(permissions.length).to.be.eql(1);
+      expect(helpers).to.be.eql([]);
+      // check correct permission is revoked
+      expect(permissions).to.deep.equal([
+        [
+          Operation.Revoke,
+          plugin,
+          dao.address,
+          AddressZero,
+          PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
+        ],
+      ]);
     });
   });
 
@@ -384,7 +421,7 @@ describe('MultisigSetup', function () {
       );
 
       // Check the return data.
-      expect(permissions.length).to.be.equal(3);
+      expect(permissions.length).to.be.equal(2);
       expect(permissions).to.deep.equal([
         [
           Operation.Revoke,
@@ -392,13 +429,6 @@ describe('MultisigSetup', function () {
           dao.address,
           AddressZero,
           UPDATE_MULTISIG_SETTINGS_PERMISSION_ID,
-        ],
-        [
-          Operation.Revoke,
-          plugin,
-          dao.address,
-          AddressZero,
-          PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID,
         ],
         [
           Operation.Revoke,

--- a/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
+++ b/packages/contracts/test/10_unit-testing/12_plugin-setup.ts
@@ -1,5 +1,5 @@
 import {createDaoProxy} from '../20_integration-testing/test-helpers';
-import {METADATA, VERSION} from '../../plugin-settings';
+import {METADATA} from '../../plugin-settings';
 import {MultisigSetup, MultisigSetup__factory} from '../../typechain';
 import {
   MULTISIG_INTERFACE,

--- a/packages/contracts/test/20_integration-testing/21_deployment.ts
+++ b/packages/contracts/test/20_integration-testing/21_deployment.ts
@@ -67,11 +67,6 @@ describe(`Deployment on network '${productionNetworkName}'`, function () {
     it('registers the setup', async () => {
       const {pluginRepo} = await loadFixture(fixture);
 
-      await pluginRepo['getVersion((uint8,uint16))']({
-        release: VERSION.release,
-        build: VERSION.build,
-      });
-
       const results = await pluginRepo['getVersion((uint8,uint16))']({
         release: VERSION.release,
         build: VERSION.build,

--- a/packages/contracts/test/20_integration-testing/21_deployment.ts
+++ b/packages/contracts/test/20_integration-testing/21_deployment.ts
@@ -67,6 +67,11 @@ describe(`Deployment on network '${productionNetworkName}'`, function () {
     it('registers the setup', async () => {
       const {pluginRepo} = await loadFixture(fixture);
 
+      await pluginRepo['getVersion((uint8,uint16))']({
+        release: VERSION.release,
+        build: VERSION.build,
+      });
+
       const results = await pluginRepo['getVersion((uint8,uint16))']({
         release: VERSION.release,
         build: VERSION.build,

--- a/packages/contracts/test/20_integration-testing/test-helpers.ts
+++ b/packages/contracts/test/20_integration-testing/test-helpers.ts
@@ -264,7 +264,7 @@ export async function updateFromBuildTest(
     .connect(deployer)
     .grant(dao.address, psp.address, DAO_PERMISSIONS.ROOT_PERMISSION_ID);
 
-  // Install previous plugin build (build previous to the latest one)
+  // Install a previous build with build number `build`
   const pluginSetupRefPreviousBuild = {
     versionTag: {
       release: VERSION.release,
@@ -312,7 +312,7 @@ export async function updateFromBuildTest(
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID
     );
 
-  // Update current build (a previous one) to the latest build
+  // Update from the previous build to the latest build
   await expect(
     updatePlugin(
       deployer,

--- a/packages/contracts/test/20_integration-testing/test-helpers.ts
+++ b/packages/contracts/test/20_integration-testing/test-helpers.ts
@@ -264,8 +264,8 @@ export async function updateFromBuildTest(
     .connect(deployer)
     .grant(dao.address, psp.address, DAO_PERMISSIONS.ROOT_PERMISSION_ID);
 
-  // Install build 1.
-  const pluginSetupRefBuild1 = {
+  // Install previous plugin build (build previous than the latest one)
+  const pluginSetupRefPreviousBuild = {
     versionTag: {
       release: VERSION.release,
       build: build,
@@ -276,7 +276,7 @@ export async function updateFromBuildTest(
     deployer,
     psp,
     dao,
-    pluginSetupRefBuild1,
+    pluginSetupRefPreviousBuild,
     ethers.utils.defaultAbiCoder.encode(
       getNamedTypesFromMetadata(
         METADATA.build.pluginSetup.prepareInstallation.inputs
@@ -292,15 +292,16 @@ export async function updateFromBuildTest(
   );
 
   // Check that the implementation of the plugin proxy matches the latest build
-  const implementationBuild1 = await PluginUpgradeableSetup__factory.connect(
-    (
-      await pluginRepo['getVersion((uint8,uint16))'](
-        pluginSetupRefBuild1.versionTag
-      )
-    ).pluginSetup,
-    deployer
-  ).implementation();
-  expect(await plugin.implementation()).to.equal(implementationBuild1);
+  const implementationPreviousBuild =
+    await PluginUpgradeableSetup__factory.connect(
+      (
+        await pluginRepo['getVersion((uint8,uint16))'](
+          pluginSetupRefPreviousBuild.versionTag
+        )
+      ).pluginSetup,
+      deployer
+    ).implementation();
+  expect(await plugin.implementation()).to.equal(implementationPreviousBuild);
 
   // Grant the PSP the permission to upgrade the plugin implementation.
   await dao
@@ -311,7 +312,7 @@ export async function updateFromBuildTest(
       PLUGIN_UUPS_UPGRADEABLE_PERMISSIONS.UPGRADE_PLUGIN_PERMISSION_ID
     );
 
-  // Update build 1 to the latest build
+  // Update current build (a previous one) to the latest build
   await expect(
     updatePlugin(
       deployer,
@@ -319,7 +320,7 @@ export async function updateFromBuildTest(
       dao,
       plugin,
       installationResults.preparedEvent.args.preparedSetupData.helpers,
-      pluginSetupRefBuild1,
+      pluginSetupRefPreviousBuild,
       pluginSetupRefLatestBuild,
       ethers.utils.defaultAbiCoder.encode(
         getNamedTypesFromMetadata(

--- a/packages/contracts/test/20_integration-testing/test-helpers.ts
+++ b/packages/contracts/test/20_integration-testing/test-helpers.ts
@@ -264,7 +264,7 @@ export async function updateFromBuildTest(
     .connect(deployer)
     .grant(dao.address, psp.address, DAO_PERMISSIONS.ROOT_PERMISSION_ID);
 
-  // Install previous plugin build (build previous than the latest one)
+  // Install previous plugin build (build previous to the latest one)
   const pluginSetupRefPreviousBuild = {
     versionTag: {
       release: VERSION.release,


### PR DESCRIPTION
PR for stop granting `UPGRADE_PLUGIN_PERMISSION_ID` to the dao. 

#### changes summary 
- in `MultisigSetup` stop granting the permission during the installation.
- in `MultisigSetup` revoke the permission to previous builds when updating.
     -  the `_currentBuild` param was renamed to `_fromBuild` to be aligned with [`IPluginSetup`](https://github.com/aragon/osx-commons/blob/7df16297f58b499fbf2fcaff59f3deaaba6be3e2/contracts/src/plugin/setup/PluginSetup.sol#L32-L36) 
- metadata updated, no new inputs needed, so the new build changes were the only ones needed.
- changelog updated.
- tests adapted and added to check changes.


Task ID: [OS-830](https://aragonassociation.atlassian.net/browse/OS-830)


[OS-830]: https://aragonassociation.atlassian.net/browse/OS-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ